### PR TITLE
feat: 회원 정보 변경 및 유형 변경 기능 구현 

### DIFF
--- a/src/main/java/com/dongrame/api/domain/user/api/UserController.java
+++ b/src/main/java/com/dongrame/api/domain/user/api/UserController.java
@@ -1,6 +1,8 @@
 package com.dongrame.api.domain.user.api;
 
+import com.dongrame.api.domain.user.dto.UserRequestDto;
 import com.dongrame.api.domain.user.dto.UserResponseDto;
+import com.dongrame.api.domain.user.dto.UserUpdateRequestDto;
 import com.dongrame.api.domain.user.service.UserService;
 import com.dongrame.api.global.config.UrlProperties;
 import com.dongrame.api.global.util.ApiResponse;
@@ -9,11 +11,12 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -25,6 +28,20 @@ public class UserController {
     private final UserService userService;
     private final UrlProperties urlProperties;
 
+    @Operation(summary = "회원 유형 설정", description = "회원 유형을 설정합니다.<br>" +
+            "- DISABLED : 장애인<br>" +
+            "- ASSISTANCE_DOG : 보조견<br>" +
+            "- ELDERLY : 노약자<br>" +
+            "- CHILD : 어린이"
+    )
+    @PostMapping("/save")
+    public ApiResponse<Long> save(
+            @RequestBody UserRequestDto userRequestDto
+    ) {
+        Long id = userService.updateUserType(userRequestDto.getUserType());
+        return ApiResponse.success(id);
+    }
+
     @Operation(summary = "내 정보 조회", description = "현재 로그인한 내 정보를 조회합니다.")
     @GetMapping("/my")
     public ApiResponse<UserResponseDto> getUser() {
@@ -32,12 +49,12 @@ public class UserController {
         return ApiResponse.success(userResponseDto);
     }
 
-    @Operation(summary = "내 이름 수정", description = "이름 수정이 가능합니다.")
-    @GetMapping("/update")
-    public ApiResponse<Long> updateUsername(
-            @RequestParam(name = "username") String username
+    @Operation(summary = "내 정보 수정", description = "정보 수정이 가능합니다.")
+    @PatchMapping("/update")
+    public ApiResponse<Long> updateUser(
+            @RequestBody UserUpdateRequestDto dto
     ) {
-        Long id = userService.updateUsername(username);
+        Long id = userService.updateUser(dto);
         return ApiResponse.success(id);
     }
 

--- a/src/main/java/com/dongrame/api/domain/user/dto/UserRequestDto.java
+++ b/src/main/java/com/dongrame/api/domain/user/dto/UserRequestDto.java
@@ -1,0 +1,16 @@
+package com.dongrame.api.domain.user.dto;
+
+import com.dongrame.api.domain.user.entity.UserType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserRequestDto {
+
+    private UserType userType;
+}

--- a/src/main/java/com/dongrame/api/domain/user/dto/UserResponseDto.java
+++ b/src/main/java/com/dongrame/api/domain/user/dto/UserResponseDto.java
@@ -1,6 +1,7 @@
 package com.dongrame.api.domain.user.dto;
 
 import com.dongrame.api.domain.user.entity.User;
+import com.dongrame.api.domain.user.entity.UserType;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,13 +12,14 @@ public class UserResponseDto {
     private String kakaoId;
     private String username;
     private String email;
+    private UserType userType;
 
     public static UserResponseDto toDto(User user) {
         return UserResponseDto.builder()
                 .kakaoId(user.getKakaoId())
                 .username(user.getNickname())
                 .email(user.getEmail())
+                .userType(user.getUserType())
                 .build();
     }
 }
-

--- a/src/main/java/com/dongrame/api/domain/user/dto/UserUpdateRequestDto.java
+++ b/src/main/java/com/dongrame/api/domain/user/dto/UserUpdateRequestDto.java
@@ -1,0 +1,14 @@
+package com.dongrame.api.domain.user.dto;
+
+import com.dongrame.api.domain.user.entity.UserType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserUpdateRequestDto {
+
+    private String username;
+    private String email;
+    private UserType userType;
+}

--- a/src/main/java/com/dongrame/api/domain/user/entity/User.java
+++ b/src/main/java/com/dongrame/api/domain/user/entity/User.java
@@ -1,7 +1,10 @@
 package com.dongrame.api.domain.user.entity;
 
+import com.dongrame.api.domain.user.dto.UserUpdateRequestDto;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -23,7 +26,6 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
     private String kakaoId;
 
     @Column(nullable = false)
@@ -35,6 +37,19 @@ public class User {
     @Column(unique = true)
     private String email;
 
+    @Enumerated(EnumType.STRING)
+    private UserType userType;
+
     @Column(nullable = false)
     private boolean active = true;
+
+    public void updateUserType(UserType userType) {
+        this.userType = userType;
+    }
+
+    public void update(UserUpdateRequestDto dto) {
+        this.nickname = dto.getUsername();
+        this.email = dto.getEmail();
+        this.userType = dto.getUserType();
+    }
 }

--- a/src/main/java/com/dongrame/api/domain/user/entity/UserType.java
+++ b/src/main/java/com/dongrame/api/domain/user/entity/UserType.java
@@ -1,0 +1,16 @@
+package com.dongrame.api.domain.user.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum UserType {
+
+    DISABLED("장애인"),
+    ASSISTANCE_DOG("보조견"),
+    ELDERLY("노약자"),
+    CHILD("어린이");
+
+    private final String name;
+}

--- a/src/main/java/com/dongrame/api/domain/user/service/UserService.java
+++ b/src/main/java/com/dongrame/api/domain/user/service/UserService.java
@@ -2,7 +2,9 @@ package com.dongrame.api.domain.user.service;
 
 import com.dongrame.api.domain.user.dao.UserRepository;
 import com.dongrame.api.domain.user.dto.UserResponseDto;
+import com.dongrame.api.domain.user.dto.UserUpdateRequestDto;
 import com.dongrame.api.domain.user.entity.User;
+import com.dongrame.api.domain.user.entity.UserType;
 import com.dongrame.api.global.auth.service.RefreshTokenService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -40,14 +42,21 @@ public class UserService {
                 .profileImage(profileImage)
                 .email(email)
                 .build();
+
         return userRepository.save(newUser).getId();
     }
 
     @Transactional
-    public Long updateUsername(String username) {
-        UserResponseDto userDto = getCurrentLoginUser();
-        User user = findByKakaoId(userDto.getKakaoId());
-        user.setNickname(username);
+    public Long updateUserType(UserType type) {
+        User user = getCurrentUser();
+        user.updateUserType(type);
+        return user.getId();
+    }
+
+    @Transactional
+    public Long updateUser(UserUpdateRequestDto dto) {
+        User user = getCurrentUser();
+        user.update(dto);
         return user.getId();
     }
 

--- a/src/main/java/com/dongrame/api/global/config/SwaggerConfig.java
+++ b/src/main/java/com/dongrame/api/global/config/SwaggerConfig.java
@@ -12,7 +12,8 @@ import org.springframework.context.annotation.Configuration;
 
 @OpenAPIDefinition(
         servers = {
-                @Server(url = "https://api.circleme.site", description = "동그라me https 서버입니다.")
+                @Server(url = "https://api.circleme.site", description = "동그라me https 서버입니다."),
+                @Server(url = "http://localhost:8050", description = "동그라me 로컬 환경 서버입니다.")
         }
 )
 @Configuration

--- a/src/main/java/com/dongrame/api/global/config/SwaggerConfig.java
+++ b/src/main/java/com/dongrame/api/global/config/SwaggerConfig.java
@@ -13,7 +13,8 @@ import org.springframework.context.annotation.Configuration;
 @OpenAPIDefinition(
         servers = {
                 @Server(url = "https://api.circleme.site", description = "동그라me https 서버입니다."),
-                @Server(url = "http://localhost:8050", description = "동그라me 로컬 환경 서버입니다.")
+                @Server(url = "http://localhost:8050", description = "동그라me 로컬 환경 서버입니다."),
+                @Server(url = "http://localhost:8080", description = "동그라me 로컬 환경 서버입니다.")
         }
 )
 @Configuration


### PR DESCRIPTION
- 회원 이름 변경 -> 회원 정보 변경으로 수정했습니다.
- 회원의 유형을 변경하는 api를 구현했습니다.

회원 유형 변경 api는 정확히 회원 유형만 변경 가능하고,
회원 정보 변경 api는 회원 정보 중 원하는 것을 변경할 수 있습니다.

회원 유형 : 
DISABLED("장애인"),
ASSISTANCE_DOG("보조견"),
ELDERLY("노약자"),
CHILD("어린이")