### PR TITLE
feat: 이미지 조회 기능 구현

### DIFF
--- a/src/main/java/com/dongrame/api/domain/file/api/FileController.java
+++ b/src/main/java/com/dongrame/api/domain/file/api/FileController.java
@@ -1,0 +1,27 @@
+package com.dongrame.api.domain.file.api;
+
+import com.dongrame.api.domain.file.service.FileService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.UrlResource;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/file")
+@Tag(name = "file", description = "파일 조회")
+public class FileController {
+
+    private final FileService fileService;
+
+    @Operation(summary = "이미지 조회", description = "이미지를 조회합니다.")
+    @GetMapping("/get")
+    public ResponseEntity<UrlResource> getFile(@RequestParam String fileUrl) {
+        return fileService.getFile(fileUrl);
+    }
+}

--- a/src/main/java/com/dongrame/api/domain/file/service/FileService.java
+++ b/src/main/java/com/dongrame/api/domain/file/service/FileService.java
@@ -1,0 +1,42 @@
+package com.dongrame.api.domain.file.service;
+
+import org.springframework.core.io.UrlResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.net.MalformedURLException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@Service
+public class FileService {
+
+    private final String uploadDir = "/uploads";
+
+    public ResponseEntity<UrlResource> getFile(String fileUrl) {
+        try {
+            Path filePath = Paths.get(fileUrl).normalize();
+            UrlResource resource = new UrlResource(filePath.toUri());
+
+            if (!resource.exists()) {
+                return ResponseEntity.notFound().build(); // 파일이 없을 경우 404 반환
+            }
+
+            String contentType = "application/octet-stream"; // 기본값
+            if (fileUrl.endsWith(".jpg") || fileUrl.endsWith(".jpeg")) {
+                contentType = "image/jpeg";
+            } else if (fileUrl.endsWith(".png")) {
+                contentType = "image/png";
+            }
+
+            return ResponseEntity.ok()
+                    .contentType(MediaType.parseMediaType(contentType))
+                    .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"" + filePath.getFileName() + "\"")
+                    .body(resource);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("파일을 읽을 수 없습니다.");
+        }
+    }
+}


### PR DESCRIPTION
File 조회를 담당하는 api를 구현했습니다.
쿼리파라미터에 이미지의 url을 넣어 조회하면 이미지가 바로 조회됩니다.